### PR TITLE
feat: add isUUID() field support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Request field validator for expressjs
       - [isObject()](#isobject)
       - [isNumber()](#isnumber)
       - [isEmail()](#isemail)
+      - [isUUID()](#isuuid)
       - [isBoolean()](#isboolean)
       - [isDate()](#isdate)
       - [dateFormat(format)](#dateformatformat)
@@ -123,6 +124,8 @@ Expects object
 Expects number
 ##### isEmail()
 Expects email
+##### isUUID()
+Expects UUID string
 ##### isBoolean()
 Expects boolean value
 ##### isDate()

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,8 @@ export interface ParamBuilder {
   isNumber(): ParamBuilder;
   /** Expect the field value to be a valid email address. */
   isEmail(): ParamBuilder;
+  /** Expect the field value to be a valid UUID string. */
+  isUUID(): ParamBuilder;
   /** Expect the field value to be a boolean (`true`, `false`, `'true'`, `'false'`). */
   isBoolean(): ParamBuilder;
   /** Expect the field value to be a date (default format `YYYY-MM-DD`). */

--- a/lib/queryBuilder/queryBuilder.js
+++ b/lib/queryBuilder/queryBuilder.js
@@ -38,6 +38,9 @@ const validateOps = () => {
   const isEmail = (validationObject) => {
     validationObject.isEmail = true;
   };
+  const isUUID = (validationObject) => {
+    validationObject.isUUID = true;
+  };
   const isBoolean = (validationObject) => {
     validationObject.isBoolean = true;
   };
@@ -121,6 +124,7 @@ const validateOps = () => {
     isArray,
     isObject,
     isEmail,
+    isUUID,
     isBoolean,
     setDateOptions,
     setNumberOptions,
@@ -187,6 +191,7 @@ const param = (paramName) => {
   const shouldExclude = (excludes) => {operations.setIncludesExcludes(validationObject, { excludes }); return fieldFunctions;};
   const isObject = () => {operations.isObject(validationObject); return fieldFunctions;};
   const isEmail = () => {operations.isEmail(validationObject); return fieldFunctions;};
+  const isUUID = () => {operations.isUUID(validationObject); return fieldFunctions;};
   const isBoolean = () => {operations.isBoolean(validationObject); return fieldFunctions;};
   const isDate = () => {operations.setDateOptions(validationObject); return fieldFunctions;};
   const dateFormat = (format) => {operations.setDateOptions(validationObject, format); return fieldFunctions;};
@@ -212,6 +217,7 @@ const param = (paramName) => {
     isArray,
     isObject,
     isEmail,
+    isUUID,
     isBoolean,
     isDate,
     isNumber,

--- a/lib/queryBuilder/queryBuilder.test.js
+++ b/lib/queryBuilder/queryBuilder.test.js
@@ -263,6 +263,17 @@ describe('Test for validateBody', () => {
       }], {}
     );
   });
+  test('validateBody validator object isUUID', () => {
+    validateBody().addParams([
+      param('test').isUUID()
+    ]);
+    expect(validator).toHaveBeenCalledWith('body',
+      [{
+        param: 'test',
+        isUUID: true,
+      }], {}
+    );
+  });
   test('validateBody validator object isDate', () => {
     validateBody().addParams([
       param('test').isDate()

--- a/lib/validator/validator.js
+++ b/lib/validator/validator.js
@@ -115,7 +115,7 @@ module.exports = (location = 'body', validation = [], response = {}) => {
         }
       };
       const checkFormat = (value, validateObj) => {
-        const { param, isRequired, isNumber, isEmail, isBoolean,
+        const { param, isRequired, isNumber, isEmail, isUUID, isBoolean,
           length, message, isDate, format, isArray, isObject, range, 
           includes, excludes, mobileNumber, customValidator } = validateObj;
 
@@ -125,6 +125,10 @@ module.exports = (location = 'body', validation = [], response = {}) => {
         const validateEmail = () => {
           const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
           return testRegEx(re, String(value).toLowerCase());
+        };
+        const validateUUID = () => {
+          const re = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+          return testRegEx(re, String(value));
         };
         const getErrorMessage = (err) => {
           return `${(message && message.toString().replace(/#value/g, value ? value.toString() : '')) || 'Invalid Field Error'}${response.debug ? (` :: ${value && value.toString()} : ${err}`) : ''}`;
@@ -226,6 +230,10 @@ module.exports = (location = 'body', validation = [], response = {}) => {
   
               if (isEmail && !validateEmail()) {
                 throw new Error('Must Be A Email Id');
+              }
+
+              if (isUUID && !validateUUID()) {
+                throw new Error('Must Be A UUID');
               }
               
               lengthCheck(length, value);

--- a/lib/validator/validator.test.js
+++ b/lib/validator/validator.test.js
@@ -893,6 +893,62 @@ describe('Test for body params', () => {
     });
   });
 
+  describe('UUID test', () => {
+    test('Test nested objects Success case - UUID test', () => {
+      const req = {
+        body: {
+          page: {
+            sorted: '550e8400-e29b-41d4-a716-446655440000'
+          }
+        }
+      };
+      const validation = [
+        {param : 'page', location : 'body', isObject : true, children : [
+            {param : 'sorted', location : 'body.page', isRequired : true, isUUID : true },
+        ]}
+      ];
+      const response = {
+        mode: 'reject'
+      };
+      const validatorfn = validaor('body', validation, response);
+      validatorfn(req, resp, next);
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(resp.status).toHaveBeenCalledTimes(0);
+      expect(resp.send).toHaveBeenCalledTimes(0);
+    });
+
+    test('Test nested objects Error case - UUID test', () => {
+      const req = {
+        body: {
+          page: {
+            sorted: 'not-a-valid-uuid'
+          }
+        }
+      };
+      const validation = [
+        {param : 'page', location : 'body', isObject : true, children : [
+            {param : 'sorted', location : 'body.page', isRequired : true, isUUID : true },
+        ]}
+      ];
+      const response = {
+        mode: 'reject'
+      };
+      const validatorfn = validaor('body', validation, response);
+      validatorfn(req, resp, next);
+      expect(next).toHaveBeenCalledTimes(0);
+      expect(resp.status).toHaveBeenCalledTimes(1);
+      expect(resp.send).toHaveBeenCalledWith({
+        error: [
+          {
+            location: 'body',
+            message: 'Invalid Field Error',
+            param: 'sorted',
+          }
+        ]
+      });
+    });
+  });
+
   describe('Date test', () => {
     test('Test nested objects Success case - Date test Format defauly YYYY-MM-DD', () => {
       const req = {


### PR DESCRIPTION
Closes #32

Adds UUID field validation support with fluent API isUUID().

Changes:
- Added query builder operation and chain method: isUUID()
- Added validator runtime check for UUID values
- Added tests for query builder mapping and validator success/error cases
- Updated TypeScript declaration (index.d.ts)
- Updated README available options list

Validation:
- npm test -- lib/queryBuilder/queryBuilder.test.js lib/validator/validator.test.js
- Result: all tests passing
